### PR TITLE
Update Navbar.tsx "join" Linking

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,7 +29,7 @@ const navbarData = {
     },
     {
       title: 'Join',
-      url: 'https://payments.curtin.edu.au/WorkshopsandEvents1/tran?uds_action_data=ZypTcEYwX3NOWCNxRkJDci8jQnRAWUIbWjFCXg5HXEAOQFxR',
+      url: 'http://tiny.cc/FRCMasterClasses',
     },
   ],
 };


### PR DESCRIPTION
Change the URL "join" points to, to be the current sign-up link. in this case masterclasses.

Bandaid fix for now